### PR TITLE
chore: Group aws-sdk-go-v2 modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      aws-sdk-go-v2:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2/*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
aws-sdk-go-v2 のモジュールをグループ化する。

refs. #9, #10