### PR TITLE
chore: Pin goreleaser/goreleaser-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      goreleaser-action:
+        applies-to: "version-updates"
+        patterns:
+          - "goreleaser/goreleaser-action"
+        update-types:
+          - "minor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: "1.23"
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
goreleaser/goreleaser-action をコミットハッシュでピン留めします。

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions